### PR TITLE
Continue to plot even when there's no agents

### DIFF
--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -150,11 +150,10 @@ function Agents.step!(abmstepper::ABMStepper, model, agent_step!, model_step!, n
     Agents.step!(model, agent_step!, model_step!, n)
 
     if Agents.nagents(model) == 0
-        @warn "The model has no agents, we can't plot anymore!"
-        error("The model has no agents, we can't plot anymore!")
+        @warn "The model has no agents"
     end
     ids = abmstepper.scheduler(model)
-    if offset == nothing
+    if isnothing(offset)
         pos[] = [model[i].pos for i in ids]
     else
         pos[] = [model[i].pos .+ offset(model[i]) for i in ids]


### PR DESCRIPTION
The changes is as the title said, the use case is when running `abm_video`. 
1. `abm_video` takes a long time to run (despite being relatively fast thanks to Julia, since rendering video + ABM is very resource heavy), but it stops when there's no agent left *and doesn't produce any output*.
2. Despite saying `can't plot anymore`, it still can. It's just ids and other agent related array/iterator are empty.
3. There's no way to know at which step the agents will all die out, unless the model in ran once. So if someone wants to create a video, they would have to run the model twice.

Here's a video for demonstation (I used agent color and heatmap parameters for the video):

https://user-images.githubusercontent.com/33273948/119382507-4c19e000-bcec-11eb-8e51-d6db30f4cff7.mp4

Since `abm_plot` use the same code it would work, too.