### PR TITLE
Agent lims

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InteractiveDynamics"
 uuid = "ec714cd0-5f51-11eb-0b6e-452e7367ff84"
 repo = "https://github.com/JuliaDynamics/InteractiveDynamics.jl.git"
-version = "0.15.2"
+version = "0.15.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -108,7 +108,7 @@ function modellims(model)
     if model.space isa Agents.ContinuousSpace
         e = model.space.extent
     elseif model.space isa Agents.DiscreteSpace
-        e = size(model.space.s)
+        e = size(model.space.s) .+ 1
     end
     return zero.(e), e
 end


### PR DESCRIPTION
Current stable version of Agents has an offset limits issue, which is mostly a function of Makie making sure things are settled in their function calls now that phase maps are center valued rather than bottom left etc.

This basically reverts a change that was needed due to other changes in AbstractPlotting previously...