### PR TITLE
Add basic support for 3D plotting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InteractiveDynamics"
 uuid = "ec714cd0-5f51-11eb-0b6e-452e7367ff84"
 repo = "https://github.com/JuliaDynamics/InteractiveDynamics.jl.git"
-version = "0.15.3"
+version = "0.16.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/examples/agents_continuous3D.jl
+++ b/examples/agents_continuous3D.jl
@@ -1,0 +1,25 @@
+using Agents
+
+@agent Particle ContinuousAgent{3} begin
+    radius::Float64
+end
+
+function initialize_model(; 
+    N = 100, space_extents = (10.0, 10.0, 10.0),
+    )
+    space = ContinuousSpace(space_extents, 1.0; periodic = true)
+    model = ABM(Particle, space)
+    for i in 1:N
+        particle = Particle(i, random_position(model), (0.0, 0.0, 0.0), rand())
+        add_agent_pos!(particle, model)
+    end
+    return model
+end
+
+model = initialize_model()
+
+using InteractiveDynamics, GLMakie
+
+as(agent) = 0.1agent.radius + 0.1
+fig, step = abm_plot(model; as)
+fig

--- a/examples/agents_schelling3d.jl
+++ b/examples/agents_schelling3d.jl
@@ -42,4 +42,5 @@ end
 using InteractiveDynamics, GLMakie
 
 model = initialize()
-fig, step = abm_play(model, agent_step!, dummystep; ac = x -> [:red, :blue][x.group], as = 0.5)
+ac(agent) = (:red, :blue)[agent.group]
+fig, step = abm_play(model, agent_step!, dummystep; ac, as = 0.5)

--- a/examples/agents_schelling3d.jl
+++ b/examples/agents_schelling3d.jl
@@ -1,0 +1,45 @@
+using Agents
+
+mutable struct SchellingAgent <: AbstractAgent
+    id::Int             # The identifier number of the agent
+    pos::NTuple{3, Int} # The x, y, z location of the agent on a 3D grid
+    mood::Bool          # whether the agent is happy in its position. (true = happy)
+    group::Int          # The group of the agent, determines mood as it interacts with neighbors
+end
+
+using Random # for reproducibility
+function initialize(; numagents = 320, griddims = (20, 20, 20), min_to_be_happy = 3, seed = 125)
+    space = GridSpace(griddims, periodic = false)
+    properties = Dict(:min_to_be_happy => min_to_be_happy)
+    rng = Random.MersenneTwister(seed)
+    model = ABM(
+        SchellingAgent, space;
+        properties, rng, scheduler = Schedulers.randomly
+    )
+    for n in 1:numagents
+        agent = SchellingAgent(n, (1, 1, 1), false, n < numagents / 2 ? 1 : 2)
+        add_agent_single!(agent, model)
+    end
+    return model
+end
+
+function agent_step!(agent, model)
+    minhappy = model.min_to_be_happy
+    count_neighbors_same_group = 0
+    for neighbor in nearby_agents(agent, model)
+        if agent.group == neighbor.group
+            count_neighbors_same_group += 1
+        end
+    end
+    if count_neighbors_same_group ≥ minhappy
+        agent.mood = true
+    else
+        move_agent_single!(agent, model)
+    end
+    return
+end
+
+using InteractiveDynamics, GLMakie
+
+model = initialize()
+fig, step = abm_play(model, agent_step!, dummystep; ac = x -> [:red, :blue][x.group], as = 0.5)

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -73,7 +73,11 @@ function abm_data_exploration(
 
     # Initialize main layout and abm axis
     figure = Figure(; resolution = (1600, 800), backgroundcolor = DEFAULT_BG)
-    abmax = figure[1,1][1,1] = Axis(figure)
+    abmax = figure[1,1][1,1] = if dimensionality(model) == 3
+        Axis3(figure)
+    else
+        Axis(figure)
+    end
 
     # initialize the ABM plot stuff
     abmstepper = abm_init_stepper_and_plot!(abmax, figure, model; kwargs...)

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -79,11 +79,7 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
 """
 function abm_plot(model; resolution = (600, 600), kwargs...)
     fig = Figure(; resolution)
-    ax = fig[1,1][1,1] = if dimensionality(model) == 3
-        Axis3(fig)
-    else
-        Axis(fig)
-    end
+    ax = fig[1,1][1,1] = dimensionality(model) == 3 ? Axis3(fig) : Axis(fig)
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
     return fig, abmstepper
 end
@@ -110,11 +106,7 @@ before the plot is updated, and "sleep" the `sleep()` time between updates.
 """
 function abm_play(model, agent_step!, model_step!; spu = 1:100, kwargs...)
     fig = Figure(; resolution = (600, 700), backgroundcolor = DEFAULT_BG)
-    ax = fig[1,1][1,1] = if dimensionality(model) == 3
-        Axis3(fig)
-    else
-        Axis(fig)
-    end
+    ax = fig[1,1][1,1] = dimensionality(model) == 3 ? Axis3(fig) : Axis(fig)
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
     abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)
     display(fig)

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -202,7 +202,7 @@ function abm_video(file, model, agent_step!, model_step! = Agents.dummystep;
     ax = fig[1,1][1,1] = if length(size(model.space.s)) == 3
         Axis3(fig; title = t, titlealign = :left, axiskwargs...)
     else
-        Axis2(fig; title = t, titlealign = :left, axiskwargs...)
+        Axis(fig; title = t, titlealign = :left, axiskwargs...)
     end
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
 

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -38,10 +38,13 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
   # am = :diamond
   am(a) = a.status == :S ? :circle : a.status == :I ? :diamond : :rect
   ```
-  Notice that `am` can be/return a `Polygon` instance, which plots each agent as an arbitrary
-  polygon. It is assumed that the origin (0, 0) is the agent's position when creating
-  the polygon. In this case, the keyword `as` is meaningless, as each polygon has its
+  Notice that for 2D models, `am` can be/return a `Polygon` instance, which plots each agent
+  as an arbitrary polygon. It is assumed that the origin (0, 0) is the agent's position when
+  creating the polygon. In this case, the keyword `as` is meaningless, as each polygon has its
   own size. Use the functions `scale, rotate2D` to transform this polygon.
+
+  3D models currently do not support having different markers. As a result, `am` cannot be a function.
+  It should be a `Mesh` or 3D primitive (such as `Sphere` or `Rect3D`).
 * `scheduler = model.scheduler`: decides the plotting order of agents
   (which matters only if there is overlap).
 * `offset = nothing`: If not `nothing`, it must be a function taking as an input an

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -1,5 +1,8 @@
 export abm_plot, abm_play, abm_video
 
+dimensionality(::Agents.ABM{<:Agents.GridSpace{D}}) where {D} = D
+dimensionality(::Agents.ABM{<:Agents.ContinuousSpace{D}}) where {D} = D
+
 """
     abm_plot(model::ABM; kwargs...) → fig, abmstepper
 Plot an agent based model by plotting each individual agent as a marker and using
@@ -73,7 +76,7 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
 """
 function abm_plot(model; resolution = (600, 600), kwargs...)
     fig = Figure(; resolution)
-    ax = fig[1,1][1,1] = if length(size(model.space.s)) == 3
+    ax = fig[1,1][1,1] = if dimensionality(model) == 3
         Axis3(fig)
     else
         Axis(fig)
@@ -104,7 +107,7 @@ before the plot is updated, and "sleep" the `sleep()` time between updates.
 """
 function abm_play(model, agent_step!, model_step!; spu = 1:100, kwargs...)
     fig = Figure(; resolution = (600, 700), backgroundcolor = DEFAULT_BG)
-    ax = fig[1,1][1,1] = if length(size(model.space.s)) == 3
+    ax = fig[1,1][1,1] = if dimensionality(model) == 3
         Axis3(fig)
     else
         Axis(fig)
@@ -199,7 +202,7 @@ function abm_video(file, model, agent_step!, model_step! = Agents.dummystep;
     end
 
     fig = Figure(; resolution, backgroundcolor = DEFAULT_BG)
-    ax = fig[1,1][1,1] = if length(size(model.space.s)) == 3
+    ax = fig[1,1][1,1] = if dimensionality(model) == 3
         Axis3(fig; title = t, titlealign = :left, axiskwargs...)
     else
         Axis(fig; title = t, titlealign = :left, axiskwargs...)

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -73,7 +73,11 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
 """
 function abm_plot(model; resolution = (600, 600), kwargs...)
     fig = Figure(; resolution)
-    ax = fig[1,1][1,1] = Axis(fig)
+    ax = fig[1,1][1,1] = if length(size(model.space.s)) == 3
+        Axis3(fig)
+    else
+        Axis(fig)
+    end
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
     return fig, abmstepper
 end
@@ -100,7 +104,11 @@ before the plot is updated, and "sleep" the `sleep()` time between updates.
 """
 function abm_play(model, agent_step!, model_step!; spu = 1:100, kwargs...)
     fig = Figure(; resolution = (600, 700), backgroundcolor = DEFAULT_BG)
-    ax = fig[1,1][1,1] = Axis(fig)
+    ax = fig[1,1][1,1] = if length(size(model.space.s)) == 3
+        Axis3(fig)
+    else
+        Axis(fig)
+    end
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
     abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)
     display(fig)
@@ -191,7 +199,11 @@ function abm_video(file, model, agent_step!, model_step! = Agents.dummystep;
     end
 
     fig = Figure(; resolution, backgroundcolor = DEFAULT_BG)
-    ax = fig[1,1][1,1] = Axis(fig; title = t, titlealign = :left, axiskwargs...)
+    ax = fig[1,1][1,1] = if length(size(model.space.s)) == 3
+        Axis3(fig; title = t, titlealign = :left, axiskwargs...)
+    else
+        Axis2(fig; title = t, titlealign = :left, axiskwargs...)
+    end
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
 
     record(fig, file; framerate) do io

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -36,14 +36,11 @@ function abm_init_stepper_and_plot!(ax, fig, model;
     )
 
     heatkwargs = merge((colormap=JULIADYNAMICS_CMAP,), heatkwargs)
-    o, e = modellims(model) # TODO: extend to 3D
+    o, e = modellims(model)
     is3d = length(o) == 3
     @assert length(o) == 2 || is3d "Only 2D and 3D spaces can be plotted."
     # TODO: once graph plotting is possible, this will be adjusted
     @assert typeof(model.space) <: Union{Agents.ContinuousSpace, Agents.DiscreteSpace}
-    # TODO: Point2f0 must be replaced by 3D version in the future
-
-    # TODO: This should be expanded into 3D (and also scale and stuff)
     xlims!(ax, o[1], e[1])
     ylims!(ax, o[2], e[2])
     is3d && zlims!(ax, o[3], e[3])

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -46,8 +46,7 @@ function abm_init_stepper_and_plot!(ax, fig, model;
     # TODO: This should be expanded into 3D (and also scale and stuff)
     xlims!(ax, o[1], e[1])
     ylims!(ax, o[2], e[2])
-    # TODO: uncomment when fixed
-    # zlims!(ax, o[3], e[3])
+    is3d && zlims!(ax, o[3], e[3])
     is3d || (ax.aspect = aspect)
 
     if !isnothing(heatarray)

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -38,7 +38,7 @@ function abm_init_stepper_and_plot!(ax, fig, model;
     heatkwargs = merge((colormap=JULIADYNAMICS_CMAP,), heatkwargs)
     o, e = modellims(model) # TODO: extend to 3D
     is3d = length(o) == 3
-    @assert length(o) == 2 || length(o) == 3 "Only 2D and 3D spaces can be plotted."
+    @assert length(o) == 2 || is3d "Only 2D and 3D spaces can be plotted."
     # TODO: once graph plotting is possible, this will be adjusted
     @assert typeof(model.space) <: Union{Agents.ContinuousSpace, Agents.DiscreteSpace}
     # TODO: Point2f0 must be replaced by 3D version in the future


### PR DESCRIPTION
Closes https://github.com/JuliaDynamics/Agents.jl/issues/369

Uses `Axis3`, `Point3f0`, `meshscatter!` if the model is 3D

TODO: 

- [x] How to handle heatmaps?
- [x] Support for different markers in `meshscatter!`
- [x] 3D equivalent of `poly!`
- [x] Set `zlims!` when Makie is tagged with the release that fixes this bug
- [x] Documentation updates