### PR TITLE
Add check for model.properties type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InteractiveDynamics"
 uuid = "ec714cd0-5f51-11eb-0b6e-452e7367ff84"
 repo = "https://github.com/JuliaDynamics/InteractiveDynamics.jl.git"
-version = "0.16.0"
+version = "0.16.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -134,7 +134,12 @@ end
 function abm_param_controls!(figure, datalayout, model, params, L)
     slidervals = Dict{Symbol, Observable}()
     for (i, (l, vals)) in enumerate(params)
-        startvalue = get(model.properties, l, vals[1])
+        if typeof(model.properties) <: Dict || typeof(model.properties) <: Tuple
+            startvalue = get(model.properties, l, vals[1])
+        else
+            startvalue = hasproperty(model.properties, l) ?
+                getproperty(model.properties, l) : vals[1]
+        end
         sll = labelslider!(figure, string(l), vals; sliderkw = Dict(:startvalue => startvalue))
         slidervals[l] = sll.slider.value # directly add the observable
         datalayout[i+L, :] = sll.layout


### PR DESCRIPTION
Fixes error when using a custom struct instead of  `Dicts` or `Tuples` for `model.properties`