### PR TITLE
Add step button

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InteractiveDynamics"
 uuid = "ec714cd0-5f51-11eb-0b6e-452e7367ff84"
 repo = "https://github.com/JuliaDynamics/InteractiveDynamics.jl.git"
-version = "0.16.2"
+version = "0.16.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -117,13 +117,17 @@ function abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)
     # preinitialize a bunch of stuff
     model0 = deepcopy(model)
     modelobs = Observable(model) # only useful for resetting
-    speed, slep, run, reset, = abm_controls_play!(fig, model, spu, false)
-    # Functionality of pressing the run button
+    speed, slep, step, run, reset, = abm_controls_play!(fig, model, spu, false)
+    # Clicking the step button
+    on(step) do clicks
+        n = speed[]
+        Agents.step!(abmstepper, model, agent_step!, model_step!, n)
+    end
+    # Clicking the run button
     isrunning = Observable(false)
     on(run) do clicks; isrunning[] = !isrunning[]; end
     on(run) do clicks
         @async while isrunning[]
-        # while isrunning[]
             n = speed[]
             model = modelobs[] # this is useful only for the reset button
             Agents.step!(abmstepper, model, agent_step!, model_step!, n)
@@ -150,17 +154,18 @@ function abm_controls_play!(fig, model, spu, add_update = false)
     slesl = labelslider!(fig, "sleep =", _s, sliderkw = Dict(:startvalue => _v))
     controllayout[1, :] = spusl.layout
     controllayout[2, :] = slesl.layout
+    step = Button(fig, label = "step")
     run = Button(fig, label = "run")
     reset = Button(fig, label = "reset")
     if add_update
         update = Button(fig, label = "update")
-        controllayout[3, :] = MakieLayout.hbox!(run, reset, update; tellwidth = false)
+        controllayout[3, :] = MakieLayout.hbox!(step, run, reset, update; tellwidth = false)
         upret = update.clicks
     else
         upret = nothing
-        controllayout[3, :] = MakieLayout.hbox!(run, reset; tellwidth = false)
+        controllayout[3, :] = MakieLayout.hbox!(step, run, reset; tellwidth = false)
     end
-    return spusl.slider.value, slesl.slider.value, run.clicks, reset.clicks, upret
+    return spusl.slider.value, slesl.slider.value, step.clicks, run.clicks, reset.clicks, upret
 end
 
 

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -95,8 +95,12 @@ The agents are plotted exactly like in [`abm_plot`](@ref), while the two functio
 `agent_step!, model_step!` decide how the model will evolve, as in the standard
 approach of Agents.jl and its `step!` function.
 
-The application has two buttons: "run" and "reset" which starts/stops the time evolution
-and resets the model to its original configuration.
+The application has three buttons:
+
+* "step": advances the simulation once for `spu` steps.
+* "run": starts/stops the continuous evolution of the model.
+* "reset": resets the model to its original configuration. 
+
 Two sliders control the animation speed: "spu" decides how many model steps should be done
 before the plot is updated, and "sleep" the `sleep()` time between updates.
 


### PR DESCRIPTION
This PR adds a new `step` button to the ABM controls.

Clicking the button results in advancing the simulation for `spu` steps.

This is distinctly different from `run` as it does not enter a loop and only executes the stepping once, allowing for more fine-grained control and exploration of the simulations.