### PR TITLE
Agent inspection on mouse hover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ update*
 Manifest.toml
 *.scss
 *.css
+*.code-workspace

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InteractiveDynamics"
 uuid = "ec714cd0-5f51-11eb-0b6e-452e7367ff84"
 repo = "https://github.com/JuliaDynamics/InteractiveDynamics.jl.git"
-version = "0.17.2"
+version = "0.18.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -15,3 +15,17 @@ abm_play
 abm_video
 abm_data_exploration
 ```
+
+## Agent inspection
+
+It is possible to inspect agents at a given position by hovering the mouse cursor over the scatter points in the agent plot.
+A tooltip will appear which by default provides the name of the agent type, its `id`, `pos`, and all other fieldnames together with their current values.
+This is especially useful for interactive exploration of micro data on the agent level.
+
+For this functionality, we draw on the powerful features of Makie's [`DataInspector`](https://makie.juliaplots.org/v0.15.1/documentation/inspector/).
+
+The tooltip can be customized both with regards to its content and its style by extending a single function and creating a specialized method for a given `A<:AbstractAgent`.
+
+```@docs
+agent2string
+```

--- a/src/InteractiveDynamics.jl
+++ b/src/InteractiveDynamics.jl
@@ -22,6 +22,7 @@ function __init__()
         include("billiards/interactive_billiard.jl")
     end
     @require Agents = "46ada45e-f475-11e8-01d0-f70cc89e6671" begin
+        include("agents/abmplot.jl")
         include("agents/stepping.jl")
         include("agents/plots_videos.jl")
         include("agents/interactive_parameters.jl")

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -45,8 +45,13 @@ function Makie.show_data(inspector::DataInspector,
     Makie.update_tooltip_alignment!(inspector, proj_pos)
     as = plot.as[]
 
-    # TODO: Generalise for use with both GridSpace and ContinuousSpace
-    pos = (plot[1][][idx].data[1], plot[1][][idx].data[2]) .|> Int
+    pos = (plot[1][][idx].data[1], plot[1][][idx].data[2])
+    s = typeof(plot.model[].space)
+    if s <: Agents.ContinuousSpace
+        pos = Float64.(pos)
+    elseif s <: Agents.GridSpace
+        pos = Int.(pos)
+    end
     a._display_text[] = agent2string(plot.model[], pos)
     a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* as .- Vec2f0(5), Vec2f0(as) .+ Vec2f0(10))
     a._px_bbox_visible[] = true
@@ -68,8 +73,13 @@ function Makie.show_data(inspector::DataInspector,
     Makie.update_tooltip_alignment!(inspector, proj_pos)
     as = plot.as[]
 
-    # TODO: Generalise for use with both GridSpace and ContinuousSpace
-    pos = (plot[1][][idx].data[1], plot[1][][idx].data[2], plot[1][][idx].data[3]) .|> Int
+    pos = (plot[1][][idx].data[1], plot[1][][idx].data[2], plot[1][][idx].data[3])
+    s = typeof(plot.model[].space)
+    if s <: Agents.ContinuousSpace
+        pos = Float64.(pos)
+    elseif s <: Agents.GridSpace
+        pos = Int.(pos)
+    end
     a._display_text[] = agent2string(plot.model[], pos)
     a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* as .- Vec2f0(5), Vec2f0(as) .+ Vec2f0(10))
     a._px_bbox_visible[] = true
@@ -88,8 +98,16 @@ Convert agent data into a string.
 Concatenate strings if there are multiple agents at given `pos`.
 """
 function agent2string(model::Agents.ABM, pos::NTuple{2, Int})
-    # TODO: pos type needs to be more lenient for use with other model spaces
     ids = Agents.ids_in_position(pos, model)
+    s = ""
+    for id in ids
+        s *= agent2string(model[id]) * "\n"
+    end
+    return s
+end
+
+function agent2string(model::Agents.ABM, pos::NTuple{2, Float64})
+    ids = Agents.nearby_ids(pos, model, 0.01)
     s = ""
     for id in ids
         s *= agent2string(model[id]) * "\n"

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -1,0 +1,21 @@
+"Define ABMPlot plotting function with some attribute defaults."
+@recipe(ABMPlot, pos, model) do scene
+    Theme(
+        # insert InteractiveDynamics theme here?   
+    )
+    Attributes(
+        ac = JULIADYNAMICS_COLORS[1],
+        as = 10,
+        am = :circle,
+        scatterkwargs = NamedTuple(),
+    )
+end
+
+# 2D space
+function Makie.plot!(abmplot::ABMPlot{<:Tuple{Vector{Point2f0}, <:Agents.ABM}})
+    scatter!(abmplot, abmplot[:pos];
+        color=abmplot[:ac], marker=abmplot[:am], markersize=abmplot[:as],
+        abmplot[:scatterkwargs]...
+    )
+    return abmplot
+end

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -1,3 +1,7 @@
+##########################################################################################
+# ABMPlot recipe
+##########################################################################################
+
 "Define ABMPlot plotting function with some attribute defaults."
 @recipe(ABMPlot, pos, model) do scene
     Theme(
@@ -17,15 +21,19 @@ function Makie.plot!(abmplot::ABMPlot{<:Tuple{Vector{Point2f0}, <:Agents.ABM}})
         color=abmplot[:ac], marker=abmplot[:am], markersize=abmplot[:as],
         abmplot[:scatterkwargs]...
     )
+    
     return abmplot
 end
 
 # 3D space
 function Makie.plot!(abmplot::ABMPlot{<:Tuple{Vector{Point3f0}, <:Agents.ABM}})
+    abmplot.am[] == :circle && (abmplot.am = Sphere(Point3f0(0), 1))
+    
     meshscatter!(abmplot, abmplot[:pos];
         color=abmplot[:ac], marker=abmplot[:am], markersize=abmplot[:as],
         abmplot[:scatterkwargs]...
     )
+    
     return abmplot
 end
 
@@ -61,11 +69,10 @@ function Makie.show_data(inspector::DataInspector,
     return true
 end
 
-# TODO: Properly implement 3D version
 # TODO: Test 3D version
 function Makie.show_data(inspector::DataInspector, 
             plot::ABMPlot{<:Tuple{Vector{Point3f0}, <:Agents.ABM}},
-            idx, ::Scatter)
+            idx, ::MeshScatter)
     a = inspector.plot.attributes
     scene = Makie.parent_scene(plot)
 
@@ -73,14 +80,14 @@ function Makie.show_data(inspector::DataInspector,
     Makie.update_tooltip_alignment!(inspector, proj_pos)
     as = plot.as[]
 
-    pos = (plot[1][][idx].data[1], plot[1][][idx].data[2], plot[1][][idx].data[3])
+    cursor_pos = (plot[1][][idx].data[1], plot[1][][idx].data[2], plot[1][][idx].data[3])
     s = typeof(plot.model[].space)
     if s <: Agents.ContinuousSpace
-        pos = Float64.(pos)
+        cursor_pos = Float64.(cursor_pos)
     elseif s <: Agents.GridSpace
-        pos = Int.(pos)
+        cursor_pos = Int.(cursor_pos)
     end
-    a._display_text[] = agent2string(plot.model[], pos)
+    a._display_text[] = agent2string(plot.model[], cursor_pos)
     a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* as .- Vec2f0(5), Vec2f0(as) .+ Vec2f0(10))
     a._px_bbox_visible[] = true
     a._bbox_visible[] = false

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -69,7 +69,6 @@ function Makie.show_data(inspector::DataInspector,
     return true
 end
 
-# TODO: Test 3D version
 function Makie.show_data(inspector::DataInspector, 
             plot::ABMPlot{<:Tuple{Vector{Point3f0}, <:Agents.ABM}},
             idx, ::MeshScatter)
@@ -97,7 +96,6 @@ function Makie.show_data(inspector::DataInspector,
 end
 
 # TODO: Add poly show_data method
-# TODO: Test 2D model with polygons
 
 DiscretePos = Union{NTuple{2, Int}, NTuple{3, Int}}
 ContinuousPos = Union{NTuple{2, Float64}, NTuple{3, Float64}}

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -19,3 +19,50 @@ function Makie.plot!(abmplot::ABMPlot{<:Tuple{Vector{Point2f0}, <:Agents.ABM}})
     )
     return abmplot
 end
+
+##########################################################################################
+# Agent inspection on mouse hover
+##########################################################################################
+
+function Makie.show_data(inspector::DataInspector, 
+            plot::ABMPlot{<:Tuple{Vector{Point2f0}, <:Agents.ABM}},
+            idx, ::Scatter)
+    a = inspector.plot.attributes
+    scene = Makie.parent_scene(plot)
+
+    proj_pos = Makie.shift_project(scene, plot, to_ndim(Point3f0, plot[1][][idx], 0))
+    Makie.update_tooltip_alignment!(inspector, proj_pos)
+    as = plot.as[]
+
+    # TODO: Generalise for use with both GridSpace and ContinuousSpace
+    pos = (plot[1][][idx].data[1], plot[1][][idx].data[2]) .|> Int
+    a._display_text[] = agent2string(plot.model[], pos)
+    a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* as .- Vec2f0(5), Vec2f0(as) .+ Vec2f0(10))
+    a._px_bbox_visible[] = true
+    a._bbox_visible[] = false
+    a._visible[] = true
+
+    return true
+end
+
+"""
+Convert agent data into a string.
+
+Concatenate strings if there are multiple agents at given `pos`.
+"""
+function agent2string(model::Agents.ABM, pos::NTuple{2, Int})
+    ids = Agents.ids_in_position(pos, model)
+    s = ""
+    for id in ids
+        s *= agent2string(model[id]) * "\n"
+    end
+    return s
+end
+
+function agent2string(agent::A) where {A<:Agents.AbstractAgent}
+    agentstring = "▶ $(nameof(A))\n"
+    for field in fieldnames(A)
+        agentstring *= "$(field): $(getproperty(agent, field))\n"
+    end
+    return agentstring
+end

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -45,14 +45,14 @@ function Makie.show_data(inspector::DataInspector,
     Makie.update_tooltip_alignment!(inspector, proj_pos)
     as = plot.as[]
 
-    pos = (plot[1][][idx].data[1], plot[1][][idx].data[2])
+    cursor_pos = (plot[1][][idx].data[1], plot[1][][idx].data[2])
     s = typeof(plot.model[].space)
     if s <: Agents.ContinuousSpace
-        pos = Float64.(pos)
+        cursor_pos = Float64.(cursor_pos)
     elseif s <: Agents.GridSpace
-        pos = Int.(pos)
+        cursor_pos = Int.(cursor_pos)
     end
-    a._display_text[] = agent2string(plot.model[], pos)
+    a._display_text[] = agent2string(plot.model[], cursor_pos)
     a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* as .- Vec2f0(5), Vec2f0(as) .+ Vec2f0(10))
     a._px_bbox_visible[] = true
     a._bbox_visible[] = false

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -44,7 +44,9 @@ function Makie.plot!(abmplot::ABMPlot{<:Tuple{Vector{<:Polygon{2}}, <:Agents.ABM
     poly!(abmplot, abmplot[:agent_pos];
         color=abmplot[:ac],
         abmplot[:scatterkwargs]...
-    )    
+    )
+    
+    return abmplot
 end
 
 ##########################################################################################

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -1,3 +1,5 @@
+export agent2string
+
 ##########################################################################################
 # ABMPlot recipe
 ##########################################################################################
@@ -134,11 +136,6 @@ end
 DiscretePos = Union{NTuple{2, Int}, NTuple{3, Int}}
 ContinuousPos = Union{NTuple{2, Float64}, NTuple{3, Float64}}
 
-"""
-Convert agent data into a string.
-
-Concatenate strings if there are multiple agents at given `pos`.
-"""
 function agent2string(model::Agents.ABM, cursor_pos::DiscretePos)
     ids = Agents.ids_in_position(cursor_pos, model)
     s = ""
@@ -161,6 +158,28 @@ function agent2string(model::Agents.ABM, cursor_pos::ContinuousPos)
     return s
 end
 
+"""
+Convert agent data into a string which is used to display all agent variables and their 
+values in the tooltip on mouse hover.  
+Concatenates strings if there are multiple agents at one position.
+
+Custom tooltips for agents can be implemented by adding a specialised method 
+for `agent2string`.
+
+Example:
+
+```
+import InteractiveDynamics.agent2string
+
+function agent2string(agent::SpecialAgent)
+    \"\"\"
+    ✨ SpecialAgent ✨
+    ID = $(agent.id)
+    Main weapon = $(agent.charisma)
+    Side weapon = $(agent.pistol)
+    \"\"\"
+```
+"""
 function agent2string(agent::A) where {A<:Agents.AbstractAgent}
     agentstring = "▶ $(nameof(A))\n"
     

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -161,6 +161,7 @@ function agent2string(model::Agents.ABM, cursor_pos::ContinuousPos)
 end
 
 """
+    agent2string(agent::A)
 Convert agent data into a string which is used to display all agent variables and their 
 values in the tooltip on mouse hover. Concatenates strings if there are multiple agents 
 at one position.
@@ -170,7 +171,7 @@ for `agent2string`.
 
 Example:
 
-```
+```julia
 import InteractiveDynamics.agent2string
 
 function agent2string(agent::SpecialAgent)

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -117,8 +117,19 @@ end
 
 function agent2string(agent::A) where {A<:Agents.AbstractAgent}
     agentstring = "▶ $(nameof(A))\n"
+    
     for field in fieldnames(A)
-        agentstring *= "$(field): $(getproperty(agent, field))\n"
+        if field != :pos
+            agentstring *= "$(field): $(getproperty(agent, field))\n"
+        else
+            if typeof(field) == DiscretePos
+                agent_pos = getproperty(agent, field)
+            else 
+                agent_pos = round.(getproperty(agent, field), digits=2)
+            end
+            agentstring *= "$(field): $agent_pos\n"
+        end
     end
+    
     return agentstring
 end

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -138,10 +138,9 @@ function agent2string(agent::A) where {A<:Agents.AbstractAgent}
         if field != :pos
             agentstring *= "$(field): $(getproperty(agent, field))\n"
         else
-            if typeof(field) == DiscretePos
-                agent_pos = getproperty(agent, field)
-            else 
-                agent_pos = round.(getproperty(agent, field), digits=2)
+            agent_pos = getproperty(agent, field)
+            if typeof(agent_pos) <: ContinuousPos
+                agent_pos = round.(agent_pos, digits=2)
             end
             agentstring *= "$(field): $agent_pos\n"
         end

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -160,8 +160,8 @@ end
 
 """
 Convert agent data into a string which is used to display all agent variables and their 
-values in the tooltip on mouse hover.  
-Concatenates strings if there are multiple agents at one position.
+values in the tooltip on mouse hover. Concatenates strings if there are multiple agents 
+at one position.
 
 Custom tooltips for agents can be implemented by adding a specialised method 
 for `agent2string`.
@@ -174,10 +174,11 @@ import InteractiveDynamics.agent2string
 function agent2string(agent::SpecialAgent)
     \"\"\"
     ✨ SpecialAgent ✨
-    ID = $(agent.id)
-    Main weapon = $(agent.charisma)
-    Side weapon = $(agent.pistol)
+    ID = \$(agent.id)
+    Main weapon = \$(agent.charisma)
+    Side weapon = \$(agent.pistol)
     \"\"\"
+end
 ```
 """
 function agent2string(agent::A) where {A<:Agents.AbstractAgent}

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -115,7 +115,13 @@ function Makie.show_data(inspector::DataInspector,
     Makie.update_tooltip_alignment!(inspector, proj_pos)
     as = plot.as[]
 
-    cursor_pos = (plot[1][][idx].data[1], plot[1][][idx].data[2]) .|> Int
+    cursor_pos = (plot[1][][idx].data[1], plot[1][][idx].data[2])
+    s = typeof(plot.model[].space)
+    if s <: Agents.ContinuousSpace
+        cursor_pos = Float64.(cursor_pos)
+    elseif s <: Agents.GridSpace
+        cursor_pos = Int.(cursor_pos)
+    end
     a._display_text[] = agent2string(plot.model[], cursor_pos)
     a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* as .- Vec2f0(5), Vec2f0(as) .+ Vec2f0(10))
     a._px_bbox_visible[] = true

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -56,6 +56,7 @@ function Makie.show_data(inspector::DataInspector,
     return true
 end
 
+# TODO: Properly implement 3D version
 # TODO: Test 3D version
 function Makie.show_data(inspector::DataInspector, 
             plot::ABMPlot{<:Tuple{Vector{Point3f0}, <:Agents.ABM}},
@@ -67,6 +68,7 @@ function Makie.show_data(inspector::DataInspector,
     Makie.update_tooltip_alignment!(inspector, proj_pos)
     as = plot.as[]
 
+    # TODO: Generalise for use with both GridSpace and ContinuousSpace
     pos = (plot[1][][idx].data[1], plot[1][][idx].data[2], plot[1][][idx].data[3]) .|> Int
     a._display_text[] = agent2string(plot.model[], pos)
     a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* as .- Vec2f0(5), Vec2f0(as) .+ Vec2f0(10))
@@ -78,6 +80,7 @@ function Makie.show_data(inspector::DataInspector,
 end
 
 # TODO: Add poly show_data method
+# TODO: Test 2D model with polygons
 
 """
 Convert agent data into a string.
@@ -85,6 +88,7 @@ Convert agent data into a string.
 Concatenate strings if there are multiple agents at given `pos`.
 """
 function agent2string(model::Agents.ABM, pos::NTuple{2, Int})
+    # TODO: pos type needs to be more lenient for use with other model spaces
     ids = Agents.ids_in_position(pos, model)
     s = ""
     for id in ids

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -20,6 +20,17 @@ function Makie.plot!(abmplot::ABMPlot{<:Tuple{Vector{Point2f0}, <:Agents.ABM}})
     return abmplot
 end
 
+# 3D space
+function Makie.plot!(abmplot::ABMPlot{<:Tuple{Vector{Point3f0}, <:Agents.ABM}})
+    meshscatter!(abmplot, abmplot[:pos];
+        color=abmplot[:ac], marker=abmplot[:am], markersize=abmplot[:as],
+        abmplot[:scatterkwargs]...
+    )
+    return abmplot
+end
+
+# TODO: Add poly plotting method
+
 ##########################################################################################
 # Agent inspection on mouse hover
 ##########################################################################################
@@ -44,6 +55,29 @@ function Makie.show_data(inspector::DataInspector,
 
     return true
 end
+
+# TODO: Test 3D version
+function Makie.show_data(inspector::DataInspector, 
+            plot::ABMPlot{<:Tuple{Vector{Point3f0}, <:Agents.ABM}},
+            idx, ::Scatter)
+    a = inspector.plot.attributes
+    scene = Makie.parent_scene(plot)
+
+    proj_pos = Makie.shift_project(scene, plot, to_ndim(Point3f0, plot[1][][idx], 0))
+    Makie.update_tooltip_alignment!(inspector, proj_pos)
+    as = plot.as[]
+
+    pos = (plot[1][][idx].data[1], plot[1][][idx].data[2], plot[1][][idx].data[3]) .|> Int
+    a._display_text[] = agent2string(plot.model[], pos)
+    a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* as .- Vec2f0(5), Vec2f0(as) .+ Vec2f0(10))
+    a._px_bbox_visible[] = true
+    a._bbox_visible[] = false
+    a._visible[] = true
+
+    return true
+end
+
+# TODO: Add poly show_data method
 
 """
 Convert agent data into a string.

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -139,8 +139,7 @@ Convert agent data into a string.
 
 Concatenate strings if there are multiple agents at given `pos`.
 """
-function agent2string(model::Agents.ABM, 
-        cursor_pos::DiscretePos)
+function agent2string(model::Agents.ABM, cursor_pos::DiscretePos)
     ids = Agents.ids_in_position(cursor_pos, model)
     s = ""
     
@@ -151,8 +150,7 @@ function agent2string(model::Agents.ABM,
     return s
 end
 
-function agent2string(model::Agents.ABM, 
-        cursor_pos::ContinuousPos)
+function agent2string(model::Agents.ABM, cursor_pos::ContinuousPos)
     ids = Agents.nearby_ids(cursor_pos, model, 0.01)
     s = ""
     
@@ -166,16 +164,23 @@ end
 function agent2string(agent::A) where {A<:Agents.AbstractAgent}
     agentstring = "▶ $(nameof(A))\n"
     
-    for field in fieldnames(A)
-        if field != :pos
-            agentstring *= "$(field): $(getproperty(agent, field))\n"
-        else
-            agent_pos = getproperty(agent, field)
-            if typeof(agent_pos) <: ContinuousPos
-                agent_pos = round.(agent_pos, digits=2)
-            end
-            agentstring *= "$(field): $agent_pos\n"
+    agentstring *= "id: $(getproperty(agent, :id))\n"
+    
+    agent_pos = getproperty(agent, :pos)
+    typeof(agent_pos) <: ContinuousPos && (agent_pos = round.(agent_pos, digits=2))
+    agentstring *= "pos: $(agent_pos)\n"
+    
+    for field in fieldnames(A)[3:end]
+        val = getproperty(agent, field)
+        V = typeof(val)
+        if V <: AbstractFloat
+            val = round(val, digits=2)
+        elseif V <: AbstractArray{<:AbstractFloat}
+            val = round.(val, digits=2)
+        elseif V <: Tuple && V <: NTuple{length(val), <:AbstractFloat}
+            val = round.(val, digits=2)
         end
+        agentstring *= "$(field): $val\n"
     end
     
     return agentstring

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -92,26 +92,35 @@ end
 # TODO: Add poly show_data method
 # TODO: Test 2D model with polygons
 
+DiscretePos = Union{NTuple{2, Int}, NTuple{3, Int}}
+ContinuousPos = Union{NTuple{2, Float64}, NTuple{3, Float64}}
+
 """
 Convert agent data into a string.
 
 Concatenate strings if there are multiple agents at given `pos`.
 """
-function agent2string(model::Agents.ABM, pos::NTuple{2, Int})
-    ids = Agents.ids_in_position(pos, model)
+function agent2string(model::Agents.ABM, 
+        cursor_pos::DiscretePos)
+    ids = Agents.ids_in_position(cursor_pos, model)
     s = ""
+    
     for id in ids
         s *= agent2string(model[id]) * "\n"
     end
+
     return s
 end
 
-function agent2string(model::Agents.ABM, pos::NTuple{2, Float64})
-    ids = Agents.nearby_ids(pos, model, 0.01)
+function agent2string(model::Agents.ABM, 
+        cursor_pos::ContinuousPos)
+    ids = Agents.nearby_ids(cursor_pos, model, 0.01)
     s = ""
+    
     for id in ids
         s *= agent2string(model[id]) * "\n"
     end
+    
     return s
 end
 

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -11,7 +11,7 @@ showing the evolution of collected data over time (if any are asked for, see bel
 The agent based model is plotted and animated exactly as in [`abm_play`](@ref),
 and the arguments `model, agent_step!, model_step!` are propagated there as-is.
 
-Calling `abm_data_exploration` returns: `figure, agent_df, model_df`. So you can save the
+Calling `abm_data_exploration` returns: `fig, agent_df, model_df`. So you can save the
 figure, but you can also access the collected data (if any).
 
 ## Interaction
@@ -78,6 +78,10 @@ function abm_data_exploration(
     # Initialize data plots and define button behavior
     abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu=spu, when=when)
 
+    display(fig)
+    return fig, df_agent, df_model
+end
+
 function abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu, when)
     speed, slep, step, run, reset, update = abm_controls_play!(fig, model, spu, true)
 
@@ -141,12 +145,12 @@ function abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu, when)
     return nothing
 end
 
-function abm_param_controls!(figure, datalayout, model, params, L)
+function abm_param_controls!(fig, datalayout, model, params, L)
     slidervals = Dict{Symbol, Observable}()
     for (i, (l, vals)) in enumerate(params)
         startvalue = has_key(model.properties, l) ?
             get_value(model.properties, l) : vals[1]
-        sll = labelslider!(figure, string(l), vals; sliderkw = Dict(:startvalue => startvalue))
+        sll = labelslider!(fig, string(l), vals; sliderkw = Dict(:startvalue => startvalue))
         slidervals[l] = sll.slider.value # directly add the observable
         datalayout[i+L, :] = sll.layout
     end
@@ -154,7 +158,7 @@ function abm_param_controls!(figure, datalayout, model, params, L)
 end
 
 function init_abm_data_plots!(
-        figure, datalayout, model, df_agent, df_model, adata, mdata, N, alabels, mlabels
+        fig, datalayout, model, df_agent, df_model, adata, mdata, N, alabels, mlabels
     )
     Agents.collect_agent_data!(df_agent, model, adata, 0)
     Agents.collect_model_data!(df_model, model, mdata, 0)
@@ -168,7 +172,7 @@ function init_abm_data_plots!(
         x = Agents.aggname(adata[i])
         val = Observable([df_agent[end, x]])
         push!(data, val)
-        ax = datalayout[i, :] = Axis(figure)
+        ax = datalayout[i, :] = Axis(fig)
         push!(axs, ax)
         ax.ylabel = isnothing(alabels) ? x : alabels[i]
         c = colorscheme[mod1(i, 3)]
@@ -182,7 +186,7 @@ function init_abm_data_plots!(
         x = Agents.aggname(mdata[i])
         val = Observable([df_model[end, x]])
         push!(data, val)
-        ax = datalayout[i+La, :] = Axis(figure)
+        ax = datalayout[i+La, :] = Axis(fig)
         push!(axs, ax)
         ax.ylabel = isnothing(mlabels) ? x : mlabels[i]
         c = colorscheme[mod1(i+La, 3)]

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -50,6 +50,7 @@ function abm_data_exploration(
         mlabels = nothing,
         when = true,
         spu = 1:100,
+        colorscheme = JULIADYNAMICS_COLORS,
         kwargs...
     )
 

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -72,13 +72,9 @@ function abm_data_exploration(
     s = 0 # current step
     P = length(params)
 
-    # Initialize main layout and abm axis
-    figure = Figure(; resolution = (1600, 800), backgroundcolor = DEFAULT_BG)
-    abmax = figure[1,1][1,1] = if dimensionality(model) == 3
-        Axis3(figure)
-    else
-        Axis(figure)
-    end
+    # Initialize main layout
+    fig, abmstepper, inspector = abm_plot(model; resolution=(1600,800); kwargs...)
+
 
     # Initialize the ABM plot stuff
     abmstepper = abm_init_stepper_and_plot!(abmax, figure, model; kwargs...)

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -55,7 +55,7 @@ function abm_data_exploration(
     )
 
     # Initialize main layout
-    fig, abmstepper, inspector = abm_plot(model;
+    fig, abmstepper = abm_plot(model;
         resolution=(1600,800), colorscheme, kwargs...
     )
 

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -56,7 +56,8 @@ function abm_data_exploration(
     # preinitialize a bunch of stuff
     model0 = deepcopy(model)
     modelobs = Observable(model) # only useful for resetting
-    ac = get(kwargs, :ac, JULIADYNAMICS_COLORS[1])
+    colorscheme = get(kwargs, :colorscheme, JULIADYNAMICS_COLORS)
+    ac = get(kwargs, :ac, colorscheme[1])
     as = get(kwargs, :as, 10)
     am = get(kwargs, :am, :circle)
     scheduler = get(kwargs, :scheduler, model.scheduler)
@@ -174,7 +175,7 @@ function init_abm_data_plots!(
         ax = datalayout[i, :] = Axis(figure)
         push!(axs, ax)
         ax.ylabel = isnothing(alabels) ? x : alabels[i]
-        c = JULIADYNAMICS_COLORS[mod1(i, 3)]
+        c = colorscheme[mod1(i, 3)]
         lines!(ax, N, val, color = c)
         scatter!(
             ax, N, val; marker = MARKER, markersize = 5Makie.px,
@@ -188,7 +189,7 @@ function init_abm_data_plots!(
         ax = datalayout[i+La, :] = Axis(figure)
         push!(axs, ax)
         ax.ylabel = isnothing(mlabels) ? x : mlabels[i]
-        c = JULIADYNAMICS_COLORS[mod1(i+La, 3)]
+        c = colorscheme[mod1(i+La, 3)]
         lines!(ax, N, val, color = c)
         scatter!(ax, N, val, marker = MARKER, markersize = 5Makie.px, color = c,
                  strokewidth = 0.5)

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -73,7 +73,7 @@ function abm_data_exploration(
     P = length(params)
 
     # Initialize main layout
-    fig, abmstepper, inspector = abm_plot(model; resolution=(1600,800); kwargs...)
+    fig, abmstepper, inspector = abm_plot(model; resolution=(1600,800), kwargs...)
 
     # Initialize data plots and define button behavior
     abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu=spu, when=when)

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -75,18 +75,19 @@ function abm_data_exploration(
     # Initialize main layout
     fig, abmstepper, inspector = abm_plot(model; resolution=(1600,800); kwargs...)
 
+    # Initialize data plots and define button behavior
+    abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu=spu, when=when)
 
-    # Initialize the ABM plot stuff
-    abmstepper = abm_init_stepper_and_plot!(abmax, figure, model; kwargs...)
-    speed, slep, step, run, reset, update = abm_controls_play!(figure, model, spu, true)
+function abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu, when)
+    speed, slep, step, run, reset, update = abm_controls_play!(fig, model, spu, true)
 
     # Initialize parameter controls & data plots
-    datalayout = figure[:, 2] = GridLayout(tellheight = false)
-    slidervals = abm_param_controls!(figure, datalayout, model, params, L)
+    datalayout = fig[:, 2] = GridLayout(tellheight = false)
+    slidervals = abm_param_controls!(fig, datalayout, model, params, L)
     if L > 0
         N = Observable([0]) # steps that data are recorded at.
         data, axs = init_abm_data_plots!(
-            figure, datalayout, model, df_agent, df_model, adata, mdata, N, alabels, mlabels
+            fig, datalayout, model, df_agent, df_model, adata, mdata, N, alabels, mlabels
         )
     end
 
@@ -119,7 +120,7 @@ function abm_data_exploration(
                 end
             end
             slep[] == 0 ? yield() : sleep(slep[])
-            isopen(figure.scene) || break # crucial, ensures computations stop if closed window.
+            isopen(fig.scene) || break # crucial, ensures computations stop if closed window.
         end
     end
 
@@ -137,8 +138,7 @@ function abm_data_exploration(
         update_abm_properties!(model, slidervals)
     end
 
-    display(figure)
-    return figure, df_agent, df_model
+    return nothing
 end
 
 function abm_param_controls!(figure, datalayout, model, params, L)

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -160,20 +160,20 @@ function abm_param_controls!(fig, datalayout, model, params, L)
 end
 
 function init_abm_data_plots!(
-        fig, datalayout, model, df_agent, df_model,
+        fig, datalayout, model, adf, mdf,
         adata, mdata, N, alabels, mlabels, colorscheme
     )
-    Agents.collect_agent_data!(df_agent, model, adata, 0)
-    Agents.collect_model_data!(df_model, model, mdata, 0)
-    La = isnothing(adata) ? 0 : size(df_agent)[2]-1
-    Lm = isnothing(mdata) ? 0 : size(df_model)[2]-1
+    Agents.collect_agent_data!(adf, model, adata, 0)
+    Agents.collect_model_data!(mdf, model, mdata, 0)
+    La = isnothing(adata) ? 0 : size(adf)[2]-1
+    Lm = isnothing(mdata) ? 0 : size(mdf)[2]-1
     data, axs = [], []
 
     # Plot all quantities
     # TODO: make scatter+line plot 1.
     for i in 1:La
         x = Agents.aggname(adata[i])
-        val = Observable([df_agent[end, x]])
+        val = Observable([adf[end, x]])
         push!(data, val)
         ax = datalayout[i, :] = Axis(fig)
         push!(axs, ax)
@@ -187,7 +187,7 @@ function init_abm_data_plots!(
     end
     for i in 1:Lm
         x = Agents.aggname(mdata[i])
-        val = Observable([df_model[end, x]])
+        val = Observable([mdf[end, x]])
         push!(data, val)
         ax = datalayout[i+La, :] = Axis(fig)
         push!(axs, ax)
@@ -204,23 +204,23 @@ function init_abm_data_plots!(
     return data, axs
 end
 
-function update_abm_data_plots!(data, axs, model, df_agent, df_model, adata, mdata, N)
-    Agents.collect_agent_data!(df_agent, model, adata, N[][end])
-    Agents.collect_model_data!(df_model, model, mdata, N[][end])
-    La = isnothing(adata) ? 0 : size(df_agent)[2]-1
-    Lm = isnothing(mdata) ? 0 : size(df_model)[2]-1
+function update_abm_data_plots!(data, axs, model, adf, mdf, adata, mdata, N)
+    Agents.collect_agent_data!(adf, model, adata, N[][end])
+    Agents.collect_model_data!(mdf, model, mdata, N[][end])
+    La = isnothing(adata) ? 0 : size(adf)[2]-1
+    Lm = isnothing(mdata) ? 0 : size(mdf)[2]-1
 
     for i in 1:La
         o = data[i]
         x = Agents.aggname(adata[i])
-        val = df_agent[end, x]
+        val = adf[end, x]
         push!(o[], val)
         o[] = o[] #update plot
     end
     for i in 1:Lm
         o = data[i+La]
         x = Agents.aggname(mdata[i])
-        val = df_model[end, x]
+        val = mdf[end, x]
         push!(o[], val)
         o[] = o[] #update plot
     end

--- a/src/agents/interactive_parameters.jl
+++ b/src/agents/interactive_parameters.jl
@@ -91,7 +91,8 @@ function abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu, when)
     if L > 0
         N = Observable([0]) # steps that data are recorded at.
         data, axs = init_abm_data_plots!(
-            fig, datalayout, model, df_agent, df_model, adata, mdata, N, alabels, mlabels
+            fig, datalayout, model, df_agent, df_model,
+            adata, mdata, N, alabels, mlabels, colorscheme
         )
     end
 
@@ -158,7 +159,8 @@ function abm_param_controls!(fig, datalayout, model, params, L)
 end
 
 function init_abm_data_plots!(
-        fig, datalayout, model, df_agent, df_model, adata, mdata, N, alabels, mlabels
+        fig, datalayout, model, df_agent, df_model,
+        adata, mdata, N, alabels, mlabels, colorscheme
     )
     Agents.collect_agent_data!(df_agent, model, adata, 0)
     Agents.collect_model_data!(df_model, model, mdata, 0)

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -62,7 +62,7 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
   But you could also define `f(model) = create_some_matrix_from_model...` and set
   `heatarray = f`. The heatmap will be updated automatically during model evolution
   in videos and interactive applications.
-* `heatkwargs = (colormap=:tokyo,)` : Keyowrds given to `Makie.heatmap` function
+* `heatkwargs = (colormap=:tokyo,)` : Keywords given to `Makie.heatmap` function
   if `heatarray` is not nothing.
 * `aspect = DataAspect()`: The aspect ratio behavior of the axis.
 * `resolution = (600, 600)`: Resolution of the figugre.

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -77,8 +77,12 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
   end
   ```
 """
-function abm_plot(model; resolution = (600, 600), kwargs...)
-    fig = Figure(; resolution)
+function abm_plot(model; 
+        resolution = (600, 600), 
+        backgroundcolor=DEFAULT_BG, 
+        kwargs...
+    )
+    fig = Figure(; resolution, backgroundcolor)
     ax = fig[1,1][1,1] = dimensionality(model) == 3 ? Axis3(fig) : Axis(fig)
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
     return fig, abmstepper
@@ -122,11 +126,13 @@ function abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)
     model0 = deepcopy(model)
     modelobs = Observable(model) # only useful for resetting
     speed, slep, step, run, reset, = abm_controls_play!(fig, model, spu, false)
+    
     # Clicking the step button
     on(step) do clicks
         n = speed[]
         Agents.step!(abmstepper, model, agent_step!, model_step!, n)
     end
+    
     # Clicking the run button
     isrunning = Observable(false)
     on(run) do clicks; isrunning[] = !isrunning[]; end
@@ -139,11 +145,13 @@ function abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)
             isopen(fig.scene) || break # crucial, ensures computations stop if closed window.
         end
     end
+    
     # Clicking the reset button
     on(reset) do clicks
         modelobs[] = deepcopy(model0)
         Agents.step!(abmstepper, modelobs[], agent_step!, model_step!, 0)
     end
+    
     return nothing
 end
 

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -77,7 +77,10 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
   end
   ```
 """
-function abm_plot(model; resolution = (600, 600), backgroundcolor=DEFAULT_BG, kwargs...)
+function abm_plot(model; 
+        resolution = (600,600), colorscheme = JULIADYNAMICS_COLORS, 
+        kwargs...
+    )
     fig = Figure(; resolution, backgroundcolor)
     ax = fig[1,1][1,1] = dimensionality(model) == 3 ? Axis3(fig) : Axis(fig)
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -88,8 +88,10 @@ function abm_plot(model;
     fig = Figure(; resolution, backgroundcolor)
     ax = fig[1,1][1,1] = dimensionality(model) == 3 ? 
         Axis3(fig; axiskwargs...) : Axis(fig; axiskwargs...)
-    abmstepper = abm_init_stepper_and_plot!(ax, fig, model;
-        ac, as, am, scheduler, offset, kwargs...)
+    abmstepper = abm_init_stepper(model;
+        ac, as, am, scheduler, offset, heatarray)
+    abm_init_plot!(ax, fig, model, abmstepper;
+        aspect, heatkwargs, add_colorbar, static_preplot!, scatterkwargs)
     inspector = DataInspector(fig.scene)
     
     # temporarily disable inspector for poly plots

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -91,6 +91,12 @@ function abm_plot(model;
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model;
         ac, as, am, scheduler, offset, kwargs...)
     inspector = DataInspector(fig.scene)
+    
+    # temporarily disable inspector for poly plots
+    if user_used_polygons(am, abmstepper.markers)
+        inspector.plot.enabled = false
+    end
+    
     return fig, abmstepper, inspector
 end
 

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -97,7 +97,7 @@ function abm_plot(model;
         inspector.plot.enabled = false
     end
     
-    return fig, abmstepper, inspector
+    return fig, abmstepper
 end
 
 ##########################################################################################
@@ -128,7 +128,7 @@ function abm_play(model, agent_step!, model_step!; spu = 1:100, kwargs...)
     fig, abmstepper, inspector = abm_plot(model; resolution = (600, 700), kwargs...)
     abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)
     display(fig)
-    return fig, abmstepper, inspector
+    return fig, abmstepper
 end
 
 function abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -80,13 +80,14 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
 function abm_plot(model; 
         resolution = (600,600), colorscheme = JULIADYNAMICS_COLORS, 
         backgroundcolor = DEFAULT_BG, as = 10, am = :circle, offset = nothing, 
-        kwargs...
+        axiskwargs = NamedTuple(), kwargs...
     )
     ac = get(kwargs, :ac, colorscheme[1])
     scheduler = get(kwargs, :scheduler, model.scheduler)
 
     fig = Figure(; resolution, backgroundcolor)
-    ax = fig[1,1][1,1] = dimensionality(model) == 3 ? Axis3(fig) : Axis(fig)
+    ax = fig[1,1][1,1] = dimensionality(model) == 3 ? 
+        Axis3(fig; axiskwargs...) : Axis(fig; axiskwargs...)
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model;
         ac, as, am, scheduler, offset, kwargs...)
     inspector = DataInspector(fig.scene)

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -81,9 +81,17 @@ function abm_plot(model;
         resolution = (600,600), colorscheme = JULIADYNAMICS_COLORS, 
         kwargs...
     )
+    backgroundcolor = get(kwargs, :backgroundcolor, DEFAULT_BG)
+    ac = get(kwargs, :ac, colorscheme[1])
+    as = get(kwargs, :as, 10)
+    am = get(kwargs, :am, :circle)
+    scheduler = get(kwargs, :scheduler, model.scheduler)
+    offset = get(kwargs, :offset, nothing)
+
     fig = Figure(; resolution, backgroundcolor)
     ax = fig[1,1][1,1] = dimensionality(model) == 3 ? Axis3(fig) : Axis(fig)
-    abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
+    abmstepper = abm_init_stepper_and_plot!(ax, fig, model;
+        ac, as, am, scheduler, offset, kwargs...)
     inspector = DataInspector(fig.scene)
     return fig, abmstepper, inspector
 end
@@ -113,7 +121,7 @@ before the plot is updated, and "sleep" the `sleep()` time between updates.
 * `spu = 1:100`: The values of the "spu" slider.
 """
 function abm_play(model, agent_step!, model_step!; spu = 1:100, kwargs...)
-    fig, abmstepper, inspector = abm_plot(model; resolution=(600,700), kwargs...)
+    fig, abmstepper, inspector = abm_plot(model; resolution = (600, 700), kwargs...)
     abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)
     display(fig)
     return fig, abmstepper, inspector
@@ -200,6 +208,11 @@ function abm_video(file, model, agent_step!, model_step! = Agents.dummystep;
         spf = 1, framerate = 30, frames = 300, resolution = (600, 600),
         title = "", showstep = true, axiskwargs = NamedTuple(), kwargs...
     )
+    ac = get(kwargs, :ac, colorscheme[1])
+    as = get(kwargs, :as, 10)
+    am = get(kwargs, :am, :circle)
+    scheduler = get(kwargs, :scheduler, model.scheduler)
+    offset = get(kwargs, :offset, nothing)
 
     # add some title stuff
     s = Observable(0) # counter of current step
@@ -217,7 +230,8 @@ function abm_video(file, model, agent_step!, model_step! = Agents.dummystep;
     else
         Axis(fig; title = t, titlealign = :left, axiskwargs...)
     end
-    abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
+    abmstepper = abm_init_stepper_and_plot!(ax, fig, model;
+        ac, as, am, scheduler, offset, kwargs...)
 
     record(fig, file; framerate) do io
         for j in 1:frames-1

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -77,11 +77,7 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
   end
   ```
 """
-function abm_plot(model; 
-        resolution = (600, 600), 
-        backgroundcolor=DEFAULT_BG, 
-        kwargs...
-    )
+function abm_plot(model; resolution = (600, 600), backgroundcolor=DEFAULT_BG, kwargs...)
     fig = Figure(; resolution, backgroundcolor)
     ax = fig[1,1][1,1] = dimensionality(model) == 3 ? Axis3(fig) : Axis(fig)
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -85,7 +85,8 @@ function abm_plot(model;
     fig = Figure(; resolution, backgroundcolor)
     ax = fig[1,1][1,1] = dimensionality(model) == 3 ? Axis3(fig) : Axis(fig)
     abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
-    return fig, abmstepper
+    inspector = DataInspector(fig.scene)
+    return fig, abmstepper, inspector
 end
 
 ##########################################################################################
@@ -113,12 +114,10 @@ before the plot is updated, and "sleep" the `sleep()` time between updates.
 * `spu = 1:100`: The values of the "spu" slider.
 """
 function abm_play(model, agent_step!, model_step!; spu = 1:100, kwargs...)
-    fig = Figure(; resolution = (600, 700), backgroundcolor = DEFAULT_BG)
-    ax = fig[1,1][1,1] = dimensionality(model) == 3 ? Axis3(fig) : Axis(fig)
-    abmstepper = abm_init_stepper_and_plot!(ax, fig, model; kwargs...)
+    fig, abmstepper, inspector = abm_plot(model; resolution=(600,700))
     abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)
     display(fig)
-    return fig, abmstepper
+    return fig, abmstepper, inspector
 end
 
 function abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -110,7 +110,7 @@ before the plot is updated, and "sleep" the `sleep()` time between updates.
 * `spu = 1:100`: The values of the "spu" slider.
 """
 function abm_play(model, agent_step!, model_step!; spu = 1:100, kwargs...)
-    fig, abmstepper, inspector = abm_plot(model; resolution=(600,700))
+    fig, abmstepper, inspector = abm_plot(model; resolution=(600,700), kwargs...)
     abm_play!(fig, abmstepper, model, agent_step!, model_step!; spu)
     display(fig)
     return fig, abmstepper, inspector

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -50,10 +50,18 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
 * `offset = nothing`: If not `nothing`, it must be a function taking as an input an
   agent and outputting an offset position vector to be added to the agent's position
   (which matters only if there is overlap).
-* `scatterkwargs = ()`: Additional keyword arguments propagated to the scatter plot.
-  If `am` is/returns Polygons, then these arguments are propagated to a `poly` plot.
+* `scatterkwargs = ()`: Additional keyword arguments propagated to the resulting ABMPlot.
 
-## Model and figure related keywords
+## Figure related keywords
+* `resolution = (600, 600)`: Resolution of the figure.
+* `colorscheme = JULIADYNAMICS_COLORS`: Vector of colors which is used as default colorscheme
+  in the figure.
+* `backgroundcolor = DEFAULT_BG`: Background color of the figure.
+* `axiskwargs = NamedTuple()`: Keyword arguments given to the main axis creation for e.g.
+  setting `xticksvisible = false`.
+* `aspect = DataAspect()`: The aspect ratio behavior of the axis.
+
+## Preplot related keywords
 * `heatarray = nothing` : A keyword that plots a heatmap over the space.
   Its values can be standard data accessors given to functions like `run!`, i.e.
   either a symbol (directly obtain model property) or a function of the model.
@@ -62,10 +70,8 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
   But you could also define `f(model) = create_some_matrix_from_model...` and set
   `heatarray = f`. The heatmap will be updated automatically during model evolution
   in videos and interactive applications.
-* `heatkwargs = (colormap=:tokyo,)` : Keywords given to `Makie.heatmap` function
+* `heatkwargs = NamedTuple()` : Keywords given to `Makie.heatmap` function
   if `heatarray` is not nothing.
-* `aspect = DataAspect()`: The aspect ratio behavior of the axis.
-* `resolution = (600, 600)`: Resolution of the figugre.
 * `static_preplot!` : A function `f(ax, model)` that plots something after the heatmap
   but before the agents. Notice that you can still make objects of this plot be visible
   above the agents using a translation in the third dimension like below:
@@ -208,9 +214,8 @@ The plotting is identical as in [`abm_plot`](@ref) and applicable keywords are p
   frame.
 * `framerate = 30`: The frame rate of the exported video.
 * `frames = 300`: How many frames to record in total, including the starting frame.
-* `resolution = (600, 600)`: Resolution of the fig.
-* `axiskwargs = NamedTuple()`: Keyword arguments given to the main axis creation for e.g.
-  setting `xticksvisible = false`.
+* `title = ""`: The title of the figure.
+* `showstep = true`: If current step should be shown in title.
 * `kwargs...`: All other keywords are propagated to [`abm_plot`](@ref).
 """
 function abm_video(file, model, agent_step!, model_step! = Agents.dummystep;

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -79,14 +79,11 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
 """
 function abm_plot(model; 
         resolution = (600,600), colorscheme = JULIADYNAMICS_COLORS, 
+        backgroundcolor = DEFAULT_BG, as = 10, am = :circle, offset = nothing, 
         kwargs...
     )
-    backgroundcolor = get(kwargs, :backgroundcolor, DEFAULT_BG)
     ac = get(kwargs, :ac, colorscheme[1])
-    as = get(kwargs, :as, 10)
-    am = get(kwargs, :am, :circle)
     scheduler = get(kwargs, :scheduler, model.scheduler)
-    offset = get(kwargs, :offset, nothing)
 
     fig = Figure(; resolution, backgroundcolor)
     ax = fig[1,1][1,1] = dimensionality(model) == 3 ? Axis3(fig) : Axis(fig)

--- a/src/agents/plots_videos.jl
+++ b/src/agents/plots_videos.jl
@@ -79,8 +79,11 @@ evolving the ABM and a heatmap in parallel with only a few lines of code.
 """
 function abm_plot(model; 
         resolution = (600,600), colorscheme = JULIADYNAMICS_COLORS, 
-        backgroundcolor = DEFAULT_BG, as = 10, am = :circle, offset = nothing, 
-        axiskwargs = NamedTuple(), kwargs...
+        backgroundcolor = DEFAULT_BG, axiskwargs = NamedTuple(), aspect = DataAspect(),
+        as = 10, am = :circle, offset = nothing,
+        heatarray = nothing, heatkwargs = NamedTuple(), add_colorbar = true, 
+        static_preplot! = default_static_preplot, scatterkwargs = NamedTuple(),
+        kwargs...
     )
     ac = get(kwargs, :ac, colorscheme[1])
     scheduler = get(kwargs, :scheduler, model.scheduler)
@@ -211,10 +214,13 @@ The plotting is identical as in [`abm_plot`](@ref) and applicable keywords are p
 * `kwargs...`: All other keywords are propagated to [`abm_plot`](@ref).
 """
 function abm_video(file, model, agent_step!, model_step! = Agents.dummystep;
-        spf = 1, framerate = 30, frames = 300, resolution = (600, 600),
-        colorscheme = JULIADYNAMICS_COLORS, backgroundcolor = DEFAULT_BG,
-        as = 10, am = :circle, offset = nothing, showstep = true, 
-        title = "", axiskwargs = NamedTuple(), kwargs...
+        spf = 1, framerate = 30, frames = 300,  title = "", showstep = true,
+        resolution = (600,600), colorscheme = JULIADYNAMICS_COLORS, 
+        backgroundcolor = DEFAULT_BG, axiskwargs = NamedTuple(), aspect = DataAspect(),
+        as = 10, am = :circle, offset = nothing,
+        heatarray = nothing, heatkwargs = NamedTuple(), add_colorbar = true,
+        static_preplot! = default_static_preplot, scatterkwargs = NamedTuple(),
+        kwargs...
     )
     ac = get(kwargs, :ac, colorscheme[1])
     scheduler = get(kwargs, :scheduler, model.scheduler)
@@ -230,9 +236,11 @@ function abm_video(file, model, agent_step!, model_step! = Agents.dummystep;
     end
     axiskwargs = (title = t, titlealign = :left, axiskwargs...)
 
-    fig, abmstepper, inspector = abm_plot(model; 
-        resolution, colorscheme, backgroundcolor, ac, as, am, scheduler, offset, 
-        axiskwargs, kwargs...
+    fig, abmstepper = abm_plot(model; 
+        resolution, colorscheme, backgroundcolor, axiskwargs, aspect,
+        ac, as, am, scheduler, offset,
+        heatarray, heatkwargs, add_colorbar, 
+        static_preplot!, scatterkwargs
     )
 
     record(fig, file; framerate) do io

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -63,7 +63,9 @@ function abm_init_stepper_and_plot!(ax, fig, model;
     end
 
     static_plot = static_preplot!(ax, model)
-    static_plot.inspectable[] = false
+    if !isnothing(static_plot)
+        static_plot.inspectable[] = false
+    end
 
     ids = scheduler(model)
     colors  = ac isa Function ? Observable(to_color.([ac(model[i]) for i ∈ ids])) : to_color(ac)

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -64,9 +64,6 @@ function abm_init_stepper_and_plot!(ax, fig, model;
 
     static_preplot!(ax, model)
 
-    if is3d && am == :circle
-        am = Sphere(Point3f0(0), 1)
-    end
     ids = scheduler(model)
     colors  = ac isa Function ? Observable(to_color.([ac(model[i]) for i ∈ ids])) : to_color(ac)
     sizes   = as isa Function ? Observable([as(model[i]) for i ∈ ids]) : as

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -62,7 +62,8 @@ function abm_init_stepper_and_plot!(ax, fig, model;
         # rowsize!(fig[1,1].fig.layout, 1, ax.scene.px_area[].widths[2]) # Colorbar height = axis height
     end
 
-    static_preplot!(ax, model)
+    static_plot = static_preplot!(ax, model)
+    static_plot.inspectable[] = false
 
     ids = scheduler(model)
     colors  = ac isa Function ? Observable(to_color.([ac(model[i]) for i ∈ ids])) : to_color(ac)

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -87,9 +87,9 @@ function abm_init_stepper_and_plot!(ax, fig, model;
         else
             markers = Observable([translate(am, p) for p in pos])
         end
-        poly!(ax, markers;
-            color=colors,
-            scatterkwargs...
+        abmplot!(ax, markers, model;
+            ac=colors,
+            scatterkwargs=scatterkwargs
         )
     else
         abmplot!(ax, pos, model;

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -84,28 +84,22 @@ function abm_init_stepper_and_plot!(ax, fig, model;
 
     # Here we make the decision of whether the user has provided markers, and thus use
     # `scatter`, or polygons, and thus use `poly`:
-    if is3d
-        meshscatter!(
-            ax, pos;
-            color = colors, marker = markers, markersize = sizes,
+    if user_used_polygons(am, markers)
+        # For polygons we always need vector, even if all agents are same polygon
+        if markers isa Observable
+            markers[] = [translate(m, p) for (m, p) in zip(markers[], pos[])]
+        else
+            markers = Observable([translate(am, p) for p in pos])
+        end
+        poly!(ax, markers;
+            color=colors,
             scatterkwargs...
         )
     else
-        if user_used_polygons(am, markers)
-            # For polygons we always need vector, even if all agents are same polygon
-            if markers isa Observable
-                markers[] = [translate(m, p) for (m, p) in zip(markers[], pos[])]
-            else
-                markers = Observable([translate(am, p) for p in pos])
-            end
-            poly!(ax, markers; color = colors, scatterkwargs...)
-        else
-            scatter!(
-                ax, pos;
-                color = colors, marker = markers, markersize = sizes,
-                scatterkwargs...
-            )
-        end
+        abmplot!(ax, pos, model;
+            ac=colors, am=markers, as=sizes, 
+            scatterkwargs=scatterkwargs
+        )
     end
     return ABMStepper(
         ac, am, as, offset, scheduler,

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -22,11 +22,7 @@ println(io, "Helper structure for stepping and updating the plot of an agent bas
 
 "Initialize the abmstepper and the plotted observables. Return the stepper."
 function abm_init_stepper_and_plot!(ax, fig, model;
-        ac = JULIADYNAMICS_COLORS[1],
-        as = 10,
-        am = :circle,
-        scheduler = model.scheduler,
-        offset = nothing,
+        ac, as, am, scheduler, offset,
         aspect = DataAspect(),
         scatterkwargs = NamedTuple(),
         heatarray = nothing,

--- a/src/agents/stepping.jl
+++ b/src/agents/stepping.jl
@@ -20,7 +20,7 @@ Base.show(io::IO, ::ABMStepper) =
 println(io, "Helper structure for stepping and updating the plot of an agent based model. ",
 "It is outputted by `abm_plot` and can be used in `Agents.step!`, see `abm_plot`.")
 
-"Initialize the abmstepper and the plotted observables. return the stepper"
+"Initialize the abmstepper and the plotted observables. Return the stepper."
 function abm_init_stepper_and_plot!(ax, fig, model;
         ac = JULIADYNAMICS_COLORS[1],
         as = 10,


### PR DESCRIPTION
Closes https://github.com/JuliaDynamics/Agents.jl/issues/538

This turned out to be a bigger endeavour than initially anticipated. I had to refactor the codebase a bit and most notably had to introduce a new Makie plot recipe.

The recipe introduces the `ABMPlot` type and its new generated functions `abmplot` and `abmplot!` which takes a list of agent positions as well as the model object and converts them into observables. Those are then accessible via the plot object itself (e.g. `plot.model[]`). The new type can be extended at will and we can easily create new methods for different use cases, e.g. for `GraphSpace` models later on.

## Showcase

Same start for every showcase example: 
```julia
using Agents
using InteractiveDynamics
using GLMakie

model, agent_step!, model_step! = Models.schelling()
```

That means I've only tested a simple 2D GridSpace model for now.

Then we try out the three main plotting functions.

```julia
## abm_plot with kwargs

ac(a) = a.group == 1 ? :red : :blue
fig, abmstepper, inspector = abm_plot(model; ac=ac)
fig
```
![abm_plot](https://user-images.githubusercontent.com/65158285/129541826-69e8f8c8-a92e-4fe7-8bc2-e149087da1b4.png)

```julia
## abm_play

fig, abmstepper, inspector = abm_play(model, agent_step!, model_step!)
fig
```
https://user-images.githubusercontent.com/65158285/129541861-1f39a78a-26d2-4023-b387-55a8eafd1c70.mp4

```julia
## abm_data_exploration
using Statistics

fig, adf, mdf = abm_data_exploration(model, agent_step!, model_step!, Dict(); 
    adata=[(:mood, mean)])
```
https://user-images.githubusercontent.com/65158285/129541896-e1f84100-f9e0-44df-b0a1-647de57c8121.mp4

Here we can see why it was necessary to introduce the new `ABMPlot` type. We can inspect scatter points as agents on the top left axis but still regularly inspect the scatter points on the observed variables on the right hand side. :)

## Sidenote

I've also introduced the possibility to use a different colourscheme than the default one. Sorry about mixing it into this PR. Realised it a bit too late that it would have been nicer to split it into another PR. It's not a very big thing but is something that was on my to-do list for a while. :)

## To do
- [x] 3D models
    - [x] Implement 3D plotting method (untested basics are already there)
    - [x] Test
- [x] 2D model with polygons
    - [x] Implement poly plotting method
    - [x] Test 
    - [x] Disable inspector until properly implemented
- [x] Test with a `ContinuousSpace` model
- [x] Test `abm_video` for 2D, 3D and poly plotting
- [x] Truncate most floats
- [x] Allow custom agent strings for tooltips.
- [x] Update docstrings and add documentation for new features
- [x] Test and document colorscheme keyword

## Further ideas
- As proposed [here](https://github.com/JuliaDynamics/Agents.jl/issues/538#issuecomment-896059948), we could improve the tooltip formatting in cases with multiple agents on one position.
- Maybe `modelobs` is unnecessary now that we could just use `plot.model[]`?
- Maybe some of the `Observable` conversions (`ac`, `am`, `as`, etc.) can be dropped when they're integrated into the plot object as Attributes. Not sure about this as it might mess with the `abmstepper` flow.


That's it from my side. Happy to answer any questions, discuss function naming as well as your ideas for extensions/changes. :)
