### PR TITLE
Add docs section about custom plots

### DIFF
--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -53,7 +53,9 @@ adata= [(:mood, mean)]
 fig, adf, mdf = abm_data_exploration(model, agent_step!, model_step!, params; adata)
 ```
 
-![Regular interactive app for data exploration][https://raw.githubusercontent.com/JuliaDynamics/JuliaDynamics/master/videos/interact/custom_plots.png]
+```@raw html
+<img width="100%" height="auto" alt="Regular interactive app for data exploration" src="https://raw.githubusercontent.com/JuliaDynamics/JuliaDynamics/master/videos/interact/custom_plots.png">
+```
 
 This will always display the data as scatterpoints connected with lines.
 In cases where more granular control over the displayed plots is needed, we need to take a few extra steps.

--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -34,7 +34,7 @@ agent2string
 
 Tracking model variables is already made easy by adding them to the `adata`/`mdata` vectors.
 
-```
+```julia
 using Agents
 using Statistics
 using InteractiveDynamics
@@ -62,7 +62,7 @@ This is done by using `Observable`s.
 We can simply add the variable in question as an `Observable` and update it after each simulation step.
 This can be done by adding a new stepping function which wraps the original `model_step!` function and the updating of the `Observable`'s value.
 
-```
+```julia
 # add the new variable as an observable
 happiness = collect(a.mood for a in allagents(model)) |> Observable
 


### PR DESCRIPTION
This docs section is added in response to https://github.com/JuliaDynamics/Agents.jl/issues/551.

@Datseris I would like to add two screenshots to this section. Where would you normally store those? I saw that you've stored the videos for the docs landing page on the JuliaDynamics github space.