### PR TITLE
Fix inspection for Makie 0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 DataStructures = "0.17, 0.18"
-Makie = "0.17, 0.18"
-OSMMakie = "0.0.5"
+Makie = "0.18"
+OSMMakie = "0.0.6"
 Observables = "0.5"
 Requires = "0.5, 1.0"
 StatsBase = "0.32, 0.33"

--- a/src/agents/inspection.jl
+++ b/src/agents/inspection.jl
@@ -28,11 +28,8 @@ function show_data_2D(inspector::DataInspector,
 
     model = plot.abmobs[].model[]
     id = collect(Agents.allids(model))[idx]
-    a._display_text[] = agent2string(model, model[id].pos)
-    a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* size .- Vec2f0(5), Vec2f0(size) .+ Vec2f0(10))
-    a._px_bbox_visible[] = true
-    a._bbox_visible[] = false
-    a._visible[] = true
+    a.text[] = agent2string(model, model[id].pos)
+    a.visible[] = true
 
     return true
 end
@@ -53,11 +50,8 @@ function show_data_poly(inspector::DataInspector,
     elseif S <: Agents.GridSpace
         agent_pos = Tuple(Int.(plot[:pos][][idx]))
     end
-    a._display_text[] = agent2string(plot.abmobs[].model[], agent_pos)
-    a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* sizes .- Vec2f0(5), Vec2f0(sizes) .+ Vec2f0(10))
-    a._px_bbox_visible[] = true
-    a._bbox_visible[] = false
-    a._visible[] = true
+    a.text[] = agent2string(plot.abmobs[].model[], agent_pos)
+    a.visible[] = true
 
     return true
 end
@@ -83,11 +77,8 @@ function show_data_3D(inspector::DataInspector,
 
     model = plot.abmobs[].model[]
     id = collect(Agents.allids(model))[idx]
-    a._display_text[] = agent2string(model, model[id].pos)
-    a._bbox2D[] = FRect2D(proj_pos .- 0.5 .* size .- Vec2f0(5), Vec2f0(size) .+ Vec2f0(10))
-    a._px_bbox_visible[] = true
-    a._bbox_visible[] = false
-    a._visible[] = true
+    a.text[] = agent2string(model, model[id].pos)
+    a.visible[] = true
 
     return true
 end


### PR DESCRIPTION
Fixes issues with `DataInspector` from #113 which raised Makie compat to `v0.18`. This PR should cover all changes made to `DataInspector`. It now looks a lot nicer as well. :)

![Screenshot_20221115_180155](https://user-images.githubusercontent.com/65158285/201982144-473028b0-2a8e-42ce-97e6-e2e8fb509980.png)
![Screenshot_20221115_180203](https://user-images.githubusercontent.com/65158285/201982148-eb6d205f-cda2-4463-8cba-e812bd30c2bd.png)

NB: This PR builds on top of the changes made in #114 and currently it's necessary to `]add OSMMakie#master` to test this PR. It can only be merged once `OSMMakie v0.0.6` is available on the public registry (it's registered and will be auto-merged with the next batch). To indicate this, I will leave this as a draft PR and only convert it to ready once the registry is updated.