### PR TITLE
[Help needed] `FixedMassABM` does not work

### DIFF
--- a/examples/agents/agents_flocking.jl
+++ b/examples/agents/agents_flocking.jl
@@ -70,7 +70,7 @@ model = init_flocking()
 const bird_polygon = Polygon(Point2f[(-0.5, -0.5), (1, 0), (-0.5, 0.5)])
 function bird_marker(b::Bird)
     φ = atan(b.vel[2], b.vel[1]) #+ π/2 + π
-    scale(rotate2D(bird_polygon, φ), 2)
+    InteractiveDynamics.scale(InteractiveDynamics.rotate2D(bird_polygon, φ), 2)
 end
 
 # simple plot
@@ -81,7 +81,6 @@ fig
 fig, ax, abmobs = abmplot(model;
     axis = (; title = "Flocking"),
     agent_step! = flocking_agent_step!,
-    model_step! = flocking_model_step!,
     am = bird_marker,
 )
 fig

--- a/examples/agents/agents_flocking.jl
+++ b/examples/agents/agents_flocking.jl
@@ -1,6 +1,7 @@
 using Agents
 using GLMakie
 using InteractiveDynamics
+using Random
 
 # Define model
 @agent Bird ContinuousAgent{2} begin
@@ -77,7 +78,7 @@ end
 fig, ax, abmobs = abmplot(model; am = bird_marker)
 fig
 
-# interactive app
+# %% interactive app
 fig, ax, abmobs = abmplot(model;
     axis = (; title = "Flocking"),
     agent_step! = flocking_agent_step!,

--- a/examples/agents/agents_flocking.jl
+++ b/examples/agents/agents_flocking.jl
@@ -2,8 +2,70 @@ using Agents
 using GLMakie
 using InteractiveDynamics
 
-model, flocking_agent_step!, flocking_model_step! = Models.flocking()
-Bird = valtype(model.agents)
+# Define model
+@agent Bird ContinuousAgent{2} begin
+    speed::Float64
+    cohere_factor::Float64
+    separation::Float64
+    separate_factor::Float64
+    match_factor::Float64
+    visual_distance::Float64
+end
+
+function init_flocking(;
+    n_birds = 100,
+    speed = 1.0,
+    cohere_factor = 0.25,
+    separation = 4.0,
+    separate_factor = 0.25,
+    match_factor = 0.01,
+    visual_distance = 5.0,
+    extent = (100, 100),
+    seed = 42,
+)
+    space2d = ContinuousSpace(extent; spacing = visual_distance/1.5)
+    rng = Random.MersenneTwister(seed)
+    birds = [Bird(
+        i,
+        Tuple(rand(rng, 2) .* extent),
+        Tuple(rand(rng, 2) * 2 .- 1),
+        speed,
+        cohere_factor,
+        separation,
+        separate_factor,
+        match_factor,
+        visual_distance,
+    ) for i in 1:n_birds]
+
+    model = FixedMassABM(birds, space2d; rng, scheduler = Schedulers.Randomly())
+    return model
+end
+
+function flocking_agent_step!(bird, model)
+    neighbor_ids = nearby_ids(bird, model, bird.visual_distance)
+    N = 0
+    match = separate = cohere = (0.0, 0.0)
+    for id in neighbor_ids
+        N += 1
+        neighbor = model[id].pos
+        heading = neighbor .- bird.pos
+
+        cohere = cohere .+ heading
+        if euclidean_distance(bird.pos, neighbor, model) < bird.separation
+            separate = separate .- heading
+        end
+        match = match .+ model[id].vel
+    end
+    N = max(N, 1)
+    cohere = cohere ./ N .* bird.cohere_factor
+    separate = separate ./ N .* bird.separate_factor
+    match = match ./ N .* bird.match_factor
+    bird.vel = (bird.vel .+ cohere .+ separate .+ match) ./ 2
+    bird.vel = bird.vel ./ norm(bird.vel)
+    move_agent!(bird, model, bird.speed)
+end
+
+model = init_flocking()
 
 const bird_polygon = Polygon(Point2f[(-0.5, -0.5), (1, 0), (-0.5, 0.5)])
 function bird_marker(b::Bird)
@@ -19,7 +81,7 @@ fig
 fig, ax, abmobs = abmplot(model;
     axis = (; title = "Flocking"),
     agent_step! = flocking_agent_step!,
-    model_step! = flocking_model_step!, 
-    am = bird_marker, 
+    model_step! = flocking_model_step!,
+    am = bird_marker,
 )
 fig

--- a/src/agents/abmplot.jl
+++ b/src/agents/abmplot.jl
@@ -18,7 +18,7 @@ Requires `Agents`. See also [`abmvideo`](@ref) and [`abmexploration`](@ref).
 ### Agent related
 * `ac, as, am` : These three keywords decide the color, size, and marker, that
   each agent will be plotted as. They can each be either a constant or a *function*,
-  which takes as an input a single agent and outputs the corresponding value. If the model 
+  which takes as an input a single agent and outputs the corresponding value. If the model
   uses a `GraphSpace`, `ac, as, am` functions instead take an *iterable of agents* in each
   position (i.e. node of the graph).
 
@@ -60,10 +60,10 @@ Requires `Agents`. See also [`abmvideo`](@ref) and [`abmexploration`](@ref).
   heatmap if `heatarray` is not nothing.
 * `static_preplot!` : A function `f(ax, model)` that plots something after the heatmap
   but before the agents.
-* `osmkwargs = NamedTuple()` : keywords directly passed to `OSMMakie.osmplot!` 
+* `osmkwargs = NamedTuple()` : keywords directly passed to `OSMMakie.osmplot!`
   if model space is `OpenStreetMapSpace`.
-* `graphplotkwargs = NamedTuple()` : keywords directly passed to 
-  [`GraphMakie.graphplot!`](https://graph.makie.org/stable/#GraphMakie.graphplot) 
+* `graphplotkwargs = NamedTuple()` : keywords directly passed to
+  [`GraphMakie.graphplot!`](https://graph.makie.org/stable/#GraphMakie.graphplot)
   if model space is `GraphSpace`.
 
 The stand-alone function `abmplot` also takes two optional `NamedTuple`s named `figure` and
@@ -82,7 +82,7 @@ The stand-alone function `abmplot` also takes two optional `NamedTuple`s named `
   1. "run": starts/stops the continuous evolution of the model.
   1. "reset model": resets the model to its initial state from right after starting the
      interactive application.
-  1. Two sliders control the animation speed: "spu" decides how many model steps should be 
+  1. Two sliders control the animation speed: "spu" decides how many model steps should be
      done before the plot is updated, and "sleep" the `sleep()` time between updates.
 * `enable_inspection = add_controls`: If `true`, enables agent inspection on mouse hover.
 * `spu = 1:50`: The values of the "spu" slider.
@@ -132,12 +132,12 @@ end
     abmplot(abmobs::ABMObservable; kwargs...) → fig, ax, abmobs
     abmplot!(ax::Axis/Axis3, abmobs::ABMObservable; kwargs...) → abmobs
 
-Same functionality as `abmplot(model; kwargs...)`/`abmplot!(ax, model; kwargs...)` 
+Same functionality as `abmplot(model; kwargs...)`/`abmplot!(ax, model; kwargs...)`
 but allows to link an already existing `ABMObservable` to the created plots.
 """
-function abmplot(abmobs::ABMObservable; 
-        figure = NamedTuple(), 
-        axis = NamedTuple(), 
+function abmplot(abmobs::ABMObservable;
+        figure = NamedTuple(),
+        axis = NamedTuple(),
         kwargs...)
     fig = Figure(; figure...)
     ax = fig[1,1][1,1] = agents_space_dimensionality(abmobs.model[]) == 3 ?
@@ -232,8 +232,8 @@ function Makie.plot!(abmplot::_ABMPlot)
 
     # Following attributes are all lifted from the recipe observables (specifically,
     # the model), see lifting.jl for source code.
-    pos, color, marker, markersize, heatobs = 
-        lift_attributes(abmplot.abmobs[].model, abmplot.ac, abmplot.as, abmplot.am, 
+    pos, color, marker, markersize, heatobs =
+        lift_attributes(abmplot.abmobs[].model, abmplot.ac, abmplot.as, abmplot.am,
             abmplot.offset, abmplot.heatarray, abmplot._used_poly)
 
     # OpenStreetMapSpace preplot
@@ -276,14 +276,14 @@ function Makie.plot!(abmplot::_ABMPlot)
             node_color = color, node_marker = marker, node_size = markersize,
             abmplot.graphplotkwargs..., # must come first to not overwrite lifted kwargs
             edge_color, edge_width)
-    elseif T<:Vector{Point2f} # 2d space
+    elseif T<:AbstractVector{Point2f} # 2d space
         if typeof(marker[])<:Vector{<:Polygon{2}}
             poly_plot = poly!(abmplot, marker; color, abmplot.scatterkwargs...)
             poly_plot.inspectable[] = false # disable inspection for poly until fixed
         else
             scatter!(abmplot, pos; color, marker, markersize, abmplot.scatterkwargs...)
         end
-    elseif T<:Vector{Point3f} # 3d space
+    elseif T<:AbstractVector{Point3f} # 3d space
         marker[] == :circle && (marker = Sphere(Point3f(0), 1))
         meshscatter!(abmplot, pos; color, marker, markersize, abmplot.scatterkwargs...)
     else

--- a/src/agents/lifting.jl
+++ b/src/agents/lifting.jl
@@ -5,7 +5,6 @@ In this file we define how agents are plotted and how the plots are updated whil
 function lift_attributes(model, ac, as, am, offset, heatarray, used_poly)
     ids = @lift(abmplot_ids($model))
     pos = @lift(abmplot_pos($model, $offset, $ids))
-    @show pos
     color = @lift(abmplot_colors($model, $ac, $ids))
     marker = @lift(abmplot_marker($model, used_poly, $am, $pos, $ids))
     markersize = @lift(abmplot_markersizes($model, $as, $ids))

--- a/src/agents/lifting.jl
+++ b/src/agents/lifting.jl
@@ -5,6 +5,7 @@ In this file we define how agents are plotted and how the plots are updated whil
 function lift_attributes(model, ac, as, am, offset, heatarray, used_poly)
     ids = @lift(abmplot_ids($model))
     pos = @lift(abmplot_pos($model, $offset, $ids))
+    @show pos
     color = @lift(abmplot_colors($model, $ac, $ids))
     marker = @lift(abmplot_marker($model, used_poly, $am, $pos, $ids))
     markersize = @lift(abmplot_markersizes($model, $as, $ids))
@@ -29,11 +30,13 @@ abmplot_ids(model::Agents.ABM{<:Agents.GraphSpace}) = eachindex(model.space.stor
 
 function abmplot_pos(model::Agents.ABM{<:SUPPORTED_SPACES}, offset, ids)
     postype = agents_space_dimensionality(model.space) == 3 ? Point3f : Point2f
-    if isnothing(offset)
+    c = if isnothing(offset)
         return [postype(model[i].pos) for i in ids]
     else
         return [postype(model[i].pos .+ offset(model[i])) for i in ids]
     end
+    r = Vector(c)
+    return r
 end
 
 function abmplot_pos(model::Agents.ABM{<:Agents.OpenStreetMapSpace}, offset, ids)
@@ -58,10 +61,10 @@ agents_space_dimensionality(::Agents.GraphSpace) = 2
 #####
 
 abmplot_colors(model::Agents.ABM{<:SUPPORTED_SPACES}, ac, ids) = to_color(ac)
-abmplot_colors(model::Agents.ABM{<:SUPPORTED_SPACES}, ac::Function, ids) = 
+abmplot_colors(model::Agents.ABM{<:SUPPORTED_SPACES}, ac::Function, ids) =
     to_color.([ac(model[i]) for i in ids])
 # in GraphSpace we iterate over a list of agents (not agent ids) at a graph node position
-abmplot_colors(model::Agents.ABM{<:Agents.GraphSpace}, ac::Function, ids) = 
+abmplot_colors(model::Agents.ABM{<:Agents.GraphSpace}, ac::Function, ids) =
     to_color.(ac(model[id] for id in model.space.stored_ids[idx]) for idx in ids)
 
 #####
@@ -107,7 +110,7 @@ abmplot_markersizes(model::Agents.ABM{<:SUPPORTED_SPACES}, as::Function, ids) =
     [as(model[i]) for i in ids]
 
 abmplot_markersizes(model::Agents.ABM{<:Agents.GraphSpace}, as, ids) = as
-abmplot_markersizes(model::Agents.ABM{<:Agents.GraphSpace}, as::Function, ids) = 
+abmplot_markersizes(model::Agents.ABM{<:Agents.GraphSpace}, as::Function, ids) =
     [as(model[id] for id in model.space.stored_ids[idx]) for idx in ids]
 
 


### PR DESCRIPTION
I am trying to update the code here so that the new model types in Agents.jl v5.7 are possible to use. But `FixedMassABM` does not work. I am getting a rather difficult to interpret error about some conversion that is nested deeply in `SizedVector`. The problem is: I am anyways making anything a normal `Vector` before the `lift` is applied. So I can't understand what is the problem.

To reproduce error: ensure you have Agents.jl v5.7 and then run the `examples/agents/agents_flocking.jl` example, which I've updated to `FixedMassABM`.